### PR TITLE
feat: Add GORM model structs for airline booking system

### DIFF
--- a/internal/models/aircraft.go
+++ b/internal/models/aircraft.go
@@ -1,0 +1,20 @@
+package models
+
+import "time"
+
+type Aircraft struct {
+	ID               uint      `gorm:"primaryKey;autoIncrement;column:id"`
+	Model            string    `gorm:"column:model;type:varchar(50);not null"`
+	Manufacturer     string    `gorm:"column:manufacturer;type:varchar(50);not null"`
+	CapacityEconomy  int       `gorm:"column:capacity_economy;not null"`
+	CapacityBusiness int       `gorm:"column:capacity_business;default:0"`
+	CapacityFirst    int       `gorm:"column:capacity_first;default:0"`
+	TotalCapacity    int       `gorm:"column:total_capacity;->"` // readonly (disable write permission unless it configured)
+	Active           bool      `gorm:"column:active;default:true"`
+	CreatedAt        time.Time `gorm:"column:created_at;autoCreateTime"`
+	UpdatedAt        time.Time `gorm:"column:updated_at;autoUpdateTime"`
+}
+
+func (Aircraft) TableName() string {
+	return "aircraft"
+}

--- a/internal/models/airlines.go
+++ b/internal/models/airlines.go
@@ -1,0 +1,17 @@
+package models
+
+import "time"
+
+type Airline struct {
+	ID        uint      `gorm:"column:id;primaryKey;autoIncrement"`
+	Code      string    `gorm:"column:code;type:varchar(3);uniqueIndex;not null"`
+	Name      string    `gorm:"column:name;type:varchar(100);not null"`
+	Country   string    `gorm:"column:country;type:varchar(2);not null"`
+	Active    bool      `gorm:"column:active;default:true"`
+	CreatedAt time.Time `gorm:"column:created_at;autoCreateTime"`
+	UpdatedAt time.Time `gorm:"column:updated_at;autoUpdateTime"`
+}
+
+func (Airline) TableName() string {
+	return "airlines"
+}

--- a/internal/models/airports.go
+++ b/internal/models/airports.go
@@ -1,0 +1,21 @@
+package models
+
+import "time"
+
+type Airport struct {
+	ID        uint      `gorm:"column:id;primaryKey;autoIncrement"`
+	Code      string    `gorm:"column:code;type:varchar(3);uniqueIndex;not null"`
+	Name      string    `gorm:"column:name;type:varchar(100);not null"`
+	City      string    `gorm:"column:city;type:varchar(50);not null"`
+	Country   string    `gorm:"column:country;type:varchar(2);not null"`
+	Timezone  string    `gorm:"column:timezone;type:varchar(50);not null"`
+	Latitude  int       `gorm:"column:latitude;type:decimal(10,8)"`
+	Longitude int       `gorm:"column:longitude;type:decimal(11,8)"`
+	Active    bool      `gorm:"column:active;default:true"`
+	CreatedAt time.Time `gorm:"column:created_at;autoCreateTime"`
+	UpdatedAt time.Time `gorm:"column:updated_at;autoUpdateTime"`
+}
+
+func (Airport) TableName() string {
+	return "airports"
+}

--- a/internal/models/api_rate_limits.go
+++ b/internal/models/api_rate_limits.go
@@ -1,0 +1,18 @@
+package models
+
+import (
+	"time"
+)
+
+type APIRateLimit struct {
+	ID           uint      `gorm:"primaryKey;column:id"`
+	Identifier   string    `gorm:"size:100;not null;column:identifier"`
+	Endpoint     string    `gorm:"size:200;not null;column:endpoint"`
+	RequestCount int       `gorm:"default:1;column:request_count"`
+	WindowStart  time.Time `gorm:"not null;column:window_start"`
+	ExpiresAt    time.Time `gorm:"not null;column:expires_at"`
+}
+
+func (APIRateLimit) TableName() string {
+	return "api_rate_limits"
+}

--- a/internal/models/booking_passengers.go
+++ b/internal/models/booking_passengers.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"time"
+)
+
+type BookingPassenger struct {
+	ID             uint      `gorm:"primaryKey;column:id"`
+	BookingID      uint      `gorm:"not null;column:booking_id"`
+	FirstName      string    `gorm:"size:50;not null;column:first_name"`
+	LastName       string    `gorm:"size:50;not null;column:last_name"`
+	DateOfBirth    time.Time `gorm:"type:date;not null;column:date_of_birth"`
+	PassportNumber string    `gorm:"size:20;column:passport_number"`
+	Nationality    string    `gorm:"size:2;column:nationality"`
+	SeatNumber     string    `gorm:"size:10;column:seat_number"`
+	MealPreference string    `gorm:"size:20;column:meal_preference"`
+	SpecialNeeds   string    `gorm:"type:text;column:special_needs"`
+	CreatedAt      time.Time `gorm:"default:CURRENT_TIMESTAMP;column:created_at"`
+	
+	// Foreign key relationship
+	Booking Booking `gorm:"foreignKey:BookingID;references:ID"`
+}
+
+func (BookingPassenger) TableName() string {
+	return "booking_passengers"
+}

--- a/internal/models/booking_payments.go
+++ b/internal/models/booking_payments.go
@@ -1,0 +1,25 @@
+package models
+
+import (
+	"time"
+)
+
+type BookingPayment struct {
+	ID              uint       `gorm:"primaryKey;column:id"`
+	BookingID       uint       `gorm:"not null;column:booking_id"`
+	PaymentMethod   string     `gorm:"not null;column:payment_method"`
+	Amount          float64    `gorm:"type:decimal(12,2);not null;column:amount"`
+	Currency        string     `gorm:"size:3;default:'USD';column:currency"`
+	PaymentStatus   string     `gorm:"default:'PENDING';column:payment_status"`
+	TransactionID   string     `gorm:"size:100;uniqueIndex;column:transaction_id"`
+	GatewayResponse string     `gorm:"type:jsonb;column:gateway_response"`
+	ProcessedAt     *time.Time `gorm:"column:processed_at"`
+	CreatedAt       time.Time  `gorm:"default:CURRENT_TIMESTAMP;column:created_at"`
+	
+	// Foreign key relationship
+	Booking Booking `gorm:"foreignKey:BookingID;references:ID"`
+}
+
+func (BookingPayment) TableName() string {
+	return "booking_payments"
+}

--- a/internal/models/bookings.go
+++ b/internal/models/bookings.go
@@ -1,0 +1,32 @@
+package models
+
+import (
+	"time"
+)
+
+type Booking struct {
+	ID              uint       `gorm:"primaryKey;column:id"`
+	BookingUUID     string     `gorm:"type:uuid;uniqueIndex;not null;column:booking_uuid"`
+	UserID          uint       `gorm:"not null;column:user_id"`
+	ScheduleID      uint       `gorm:"not null;column:schedule_id"`
+	ClassType       string     `gorm:"not null;column:class_type"`
+	PassengerCount  int16      `gorm:"not null;default:1;column:passenger_count"`
+	TotalAmount     float64    `gorm:"type:decimal(12,2);not null;column:total_amount"`
+	Status          string     `gorm:"default:'PENDING';column:status"`
+	SeatNumbers     string     `gorm:"type:jsonb;column:seat_numbers"`
+	SpecialRequests string     `gorm:"type:text;column:special_requests"`
+	BookingSource   string     `gorm:"size:20;default:'WEB';column:booking_source"`
+	ExpiresAt       *time.Time `gorm:"column:expires_at"`
+	ConfirmedAt     *time.Time `gorm:"column:confirmed_at"`
+	CancelledAt     *time.Time `gorm:"column:cancelled_at"`
+	CreatedAt       time.Time  `gorm:"default:CURRENT_TIMESTAMP;column:created_at"`
+	UpdatedAt       time.Time  `gorm:"default:CURRENT_TIMESTAMP;column:updated_at"`
+
+	// Foreign key relationships
+	User     User           `gorm:"foreignKey:UserID;references:ID"`
+	Schedule FlightSchedule `gorm:"foreignKey:ScheduleID;references:ID"`
+}
+
+func (Booking) TableName() string {
+	return "bookings"
+}

--- a/internal/models/compensation_rules.go
+++ b/internal/models/compensation_rules.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	"time"
+)
+
+type CompensationRule struct {
+	ID                       uint       `gorm:"primaryKey;column:id"`
+	AirlineID                uint       `gorm:"not null;column:airline_id"`
+	Region                   string     `gorm:"size:10;not null;column:region"`
+	FlightType               string     `gorm:"not null;column:flight_type"`
+	DelayThresholdMinutes    int        `gorm:"not null;column:delay_threshold_minutes"`
+	CompensationAmount       float64    `gorm:"type:decimal(10,2);not null;column:compensation_amount"`
+	CompensationType         string     `gorm:"not null;column:compensation_type"`
+	PriorityClassMultiplier  float64    `gorm:"type:decimal(3,2);default:1.00;column:priority_class_multiplier"`
+	Active                   bool       `gorm:"default:true;column:active"`
+	EffectiveFrom            time.Time  `gorm:"type:date;not null;column:effective_from"`
+	EffectiveTo              *time.Time `gorm:"type:date;column:effective_to"`
+	CreatedAt                time.Time  `gorm:"default:CURRENT_TIMESTAMP;column:created_at"`
+	UpdatedAt                time.Time  `gorm:"default:CURRENT_TIMESTAMP;column:updated_at"`
+	
+	// Foreign key relationship
+	Airline Airline `gorm:"foreignKey:AirlineID;references:ID"`
+}
+
+func (CompensationRule) TableName() string {
+	return "compensation_rules"
+}

--- a/internal/models/flight_inventory.go
+++ b/internal/models/flight_inventory.go
@@ -1,0 +1,28 @@
+package models
+
+import (
+	"time"
+)
+
+type FlightInventory struct {
+	ID               uint      `gorm:"primaryKey;column:id"`
+	ScheduleID       uint      `gorm:"not null;column:schedule_id"`
+	ClassType        string    `gorm:"not null;column:class_type"`
+	TotalSeats       int       `gorm:"not null;column:total_seats"`
+	AvailableSeats   int       `gorm:"not null;column:available_seats"`
+	ReservedSeats    int       `gorm:"default:0;column:reserved_seats"`
+	ConfirmedSeats   int       `gorm:"default:0;column:confirmed_seats"`
+	BlockedSeats     int       `gorm:"default:0;column:blocked_seats"`
+	OverbookingLimit int       `gorm:"default:0;column:overbooking_limit"`
+	CurrentPrice     float64   `gorm:"type:decimal(10,2);not null;column:current_price"`
+	Version          int       `gorm:"default:1;column:version"`
+	LastUpdated      time.Time `gorm:"default:CURRENT_TIMESTAMP;column:last_updated"`
+	CreatedAt        time.Time `gorm:"default:CURRENT_TIMESTAMP;column:created_at"`
+	
+	// Foreign key relationship
+	Schedule FlightSchedule `gorm:"foreignKey:ScheduleID;references:ID"`
+}
+
+func (FlightInventory) TableName() string {
+	return "flight_inventory"
+}

--- a/internal/models/flight_schedules.go
+++ b/internal/models/flight_schedules.go
@@ -1,0 +1,38 @@
+package models
+
+import (
+	"time"
+)
+
+type FlightStatus string
+
+const (
+	FlightStatusScheduled FlightStatus = "SCHEDULED"
+	FlightStatusDelayed   FlightStatus = "DELAYED"
+	FlightStatusCancelled FlightStatus = "CANCELLED"
+	FlightStatusDeparted  FlightStatus = "DEPARTED"
+	FlightStatusArrived   FlightStatus = "ARRIVED"
+)
+
+type FlightSchedule struct {
+	ID                   uint64        `gorm:"primaryKey;autoIncrement;column:id"`
+	FlightID             uint          `gorm:"column:flight_id;not null"`
+	DepartureTime        time.Time     `gorm:"column:departure_time;not null"`
+	ArrivalTime          time.Time     `gorm:"column:arrival_time;not null"`
+	Status               FlightStatus  `gorm:"column:status;type:flight_status;default:'SCHEDULED'"`
+	Gate                 *string       `gorm:"column:gate;type:varchar(10)"`
+	Terminal             *string       `gorm:"column:terminal;type:varchar(10)"`
+	ActualDepartureTime  *time.Time    `gorm:"column:actual_departure_time"`
+	ActualArrivalTime    *time.Time    `gorm:"column:actual_arrival_time"`
+	DelayMinutes         int           `gorm:"column:delay_minutes;default:0"`
+	CancellationReason   *string       `gorm:"column:cancellation_reason;type:text"`
+	CreatedAt            time.Time     `gorm:"column:created_at;autoCreateTime"`
+	UpdatedAt            time.Time     `gorm:"column:updated_at;autoUpdateTime"`
+
+	// Foreign key relationship
+	Flight Flight `gorm:"foreignKey:FlightID;references:ID"`
+}
+
+func (FlightSchedule) TableName() string {
+	return "flight_schedules"
+}

--- a/internal/models/flights.go
+++ b/internal/models/flights.go
@@ -1,0 +1,32 @@
+package models
+
+import (
+	"time"
+)
+
+type Flight struct {
+	ID                   uint      `gorm:"primaryKey;autoIncrement;column:id"`
+	FlightNumber         string    `gorm:"column:flight_number;type:varchar(10);not null"`
+	AirlineID            uint      `gorm:"column:airline_id;not null"`
+	DepartureAirportID   uint      `gorm:"column:departure_airport_id;not null"`
+	ArrivalAirportID     uint      `gorm:"column:arrival_airport_id;not null"`
+	AircraftID           uint      `gorm:"column:aircraft_id;not null"`
+	BasePriceEconomy     float64   `gorm:"column:base_price_economy;type:decimal(10,2);not null"`
+	BasePriceBusiness    *float64  `gorm:"column:base_price_business;type:decimal(10,2)"`
+	BasePriceFirst       *float64  `gorm:"column:base_price_first;type:decimal(10,2)"`
+	DurationMinutes      int       `gorm:"column:duration_minutes;not null"`
+	DistanceKm           *int      `gorm:"column:distance_km"`
+	Active               bool      `gorm:"column:active;default:true"`
+	CreatedAt            time.Time `gorm:"column:created_at;autoCreateTime"`
+	UpdatedAt            time.Time `gorm:"column:updated_at;autoUpdateTime"`
+
+	// Foreign key relationships
+	Airline           Airline `gorm:"foreignKey:AirlineID;references:ID"`
+	DepartureAirport  Airport `gorm:"foreignKey:DepartureAirportID;references:ID"`
+	ArrivalAirport    Airport `gorm:"foreignKey:ArrivalAirportID;references:ID"`
+	Aircraft          Aircraft `gorm:"foreignKey:AircraftID;references:ID"`
+}
+
+func (Flight) TableName() string {
+	return "flights"
+}

--- a/internal/models/overbooking_history.go
+++ b/internal/models/overbooking_history.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"time"
+)
+
+type OverbookingHistory struct {
+	ID                   uint      `gorm:"primaryKey;column:id"`
+	ScheduleID           uint      `gorm:"not null;column:schedule_id"`
+	ClassType            string    `gorm:"not null;column:class_type"`
+	TotalBookings        int       `gorm:"not null;column:total_bookings"`
+	ActualCapacity       int       `gorm:"not null;column:actual_capacity"`
+	OverbookingCount     int       `gorm:"not null;column:overbooking_count"`
+	NoShowCount          int       `gorm:"default:0;column:no_show_count"`
+	DeniedBoardingCount  int       `gorm:"default:0;column:denied_boarding_count"`
+	CompensationAmount   float64   `gorm:"type:decimal(10,2);default:0;column:compensation_amount"`
+	ResolutionStatus     string    `gorm:"default:'PENDING';column:resolution_status"`
+	CreatedAt            time.Time `gorm:"default:CURRENT_TIMESTAMP;column:created_at"`
+	
+	// Foreign key relationship
+	Schedule FlightSchedule `gorm:"foreignKey:ScheduleID;references:ID"`
+}
+
+func (OverbookingHistory) TableName() string {
+	return "overbooking_history"
+}

--- a/internal/models/overbooking_rules.go
+++ b/internal/models/overbooking_rules.go
@@ -1,0 +1,30 @@
+package models
+
+import (
+	"time"
+)
+
+type OverbookingRule struct {
+	ID                  uint       `gorm:"primaryKey;column:id"`
+	AirlineID           uint       `gorm:"not null;column:airline_id"`
+	AircraftID          *uint      `gorm:"column:aircraft_id"`
+	RouteType           string     `gorm:"default:'ALL';column:route_type"`
+	ClassType           string     `gorm:"default:'ALL';column:class_type"`
+	BaseOverbookingRate float64    `gorm:"type:decimal(5,2);not null;column:base_overbooking_rate"`
+	MaxOverbookingRate  float64    `gorm:"type:decimal(5,2);not null;column:max_overbooking_rate"`
+	NoShowRate          float64    `gorm:"type:decimal(5,2);not null;column:no_show_rate"`
+	SeasonalFactor      float64    `gorm:"type:decimal(3,2);default:1.00;column:seasonal_factor"`
+	Active              bool       `gorm:"default:true;column:active"`
+	EffectiveFrom       time.Time  `gorm:"type:date;not null;column:effective_from"`
+	EffectiveTo         *time.Time `gorm:"type:date;column:effective_to"`
+	CreatedAt           time.Time  `gorm:"default:CURRENT_TIMESTAMP;column:created_at"`
+	UpdatedAt           time.Time  `gorm:"default:CURRENT_TIMESTAMP;column:updated_at"`
+	
+	// Foreign key relationships
+	Airline  Airline  `gorm:"foreignKey:AirlineID;references:ID"`
+	Aircraft *Aircraft `gorm:"foreignKey:AircraftID;references:ID"`
+}
+
+func (OverbookingRule) TableName() string {
+	return "overbooking_rules"
+}

--- a/internal/models/popular_routes.go
+++ b/internal/models/popular_routes.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"time"
+)
+
+type PopularRoute struct {
+	ID                  uint       `gorm:"primaryKey;column:id"`
+	DepartureAirportID  uint       `gorm:"not null;column:departure_airport_id"`
+	ArrivalAirportID    uint       `gorm:"not null;column:arrival_airport_id"`
+	SearchCount         int64      `gorm:"default:0;column:search_count"`
+	BookingCount        int64      `gorm:"default:0;column:booking_count"`
+	LastSearched        *time.Time `gorm:"column:last_searched"`
+	LastBooked          *time.Time `gorm:"column:last_booked"`
+	Score               float64    `gorm:"type:decimal(8,2);column:score"`
+	CreatedAt           time.Time  `gorm:"default:CURRENT_TIMESTAMP;column:created_at"`
+	UpdatedAt           time.Time  `gorm:"default:CURRENT_TIMESTAMP;column:updated_at"`
+	
+	// Foreign key relationships
+	DepartureAirport Airport `gorm:"foreignKey:DepartureAirportID;references:ID"`
+	ArrivalAirport   Airport `gorm:"foreignKey:ArrivalAirportID;references:ID"`
+}
+
+func (PopularRoute) TableName() string {
+	return "popular_routes"
+}

--- a/internal/models/search_analytics.go
+++ b/internal/models/search_analytics.go
@@ -1,0 +1,32 @@
+package models
+
+import (
+	"time"
+	"net"
+)
+
+type SearchAnalytics struct {
+	ID                   uint       `gorm:"primaryKey;column:id"`
+	UserID               *uint      `gorm:"column:user_id"`
+	DepartureAirportID   *uint      `gorm:"column:departure_airport_id"`
+	ArrivalAirportID     *uint      `gorm:"column:arrival_airport_id"`
+	DepartureDate        *time.Time `gorm:"type:date;column:departure_date"`
+	ReturnDate           *time.Time `gorm:"type:date;column:return_date"`
+	PassengerCount       int16      `gorm:"default:1;column:passenger_count"`
+	ClassPreference      string     `gorm:"column:class_preference"`
+	SearchResultCount    int        `gorm:"column:search_result_count"`
+	ResponseTimeMs       int        `gorm:"column:response_time_ms"`
+	ConvertedToBooking   bool       `gorm:"default:false;column:converted_to_booking"`
+	UserAgent            string     `gorm:"type:text;column:user_agent"`
+	IPAddress            net.IP     `gorm:"type:inet;column:ip_address"`
+	CreatedAt            time.Time  `gorm:"default:CURRENT_TIMESTAMP;column:created_at"`
+	
+	// Foreign key relationships
+	User             *User    `gorm:"foreignKey:UserID;references:ID"`
+	DepartureAirport *Airport `gorm:"foreignKey:DepartureAirportID;references:ID"`
+	ArrivalAirport   *Airport `gorm:"foreignKey:ArrivalAirportID;references:ID"`
+}
+
+func (SearchAnalytics) TableName() string {
+	return "search_analytics"
+}

--- a/internal/models/seat_assignments.go
+++ b/internal/models/seat_assignments.go
@@ -1,0 +1,29 @@
+package models
+
+import (
+	"time"
+)
+
+type SeatAssignment struct {
+	ID          uint       `gorm:"primaryKey;column:id"`
+	ScheduleID  uint       `gorm:"not null;column:schedule_id"`
+	SeatID      uint       `gorm:"not null;column:seat_id"`
+	BookingID   *uint      `gorm:"column:booking_id"`
+	PassengerID *uint      `gorm:"column:passenger_id"`
+	Status      string     `gorm:"default:'AVAILABLE';column:status"`
+	ReservedAt  *time.Time `gorm:"column:reserved_at"`
+	ConfirmedAt *time.Time `gorm:"column:confirmed_at"`
+	Version     int        `gorm:"default:1;column:version"`
+	CreatedAt   time.Time  `gorm:"default:CURRENT_TIMESTAMP;column:created_at"`
+	UpdatedAt   time.Time  `gorm:"default:CURRENT_TIMESTAMP;column:updated_at"`
+	
+	// Foreign key relationships
+	Schedule  FlightSchedule    `gorm:"foreignKey:ScheduleID;references:ID"`
+	Seat      SeatMap           `gorm:"foreignKey:SeatID;references:ID"`
+	Booking   *Booking          `gorm:"foreignKey:BookingID;references:ID"`
+	Passenger *BookingPassenger `gorm:"foreignKey:PassengerID;references:ID"`
+}
+
+func (SeatAssignment) TableName() string {
+	return "seat_assignments"
+}

--- a/internal/models/seat_maps.go
+++ b/internal/models/seat_maps.go
@@ -1,0 +1,26 @@
+package models
+
+import (
+	"time"
+)
+
+type SeatMap struct {
+	ID           uint      `gorm:"primaryKey;column:id"`
+	AircraftID   uint      `gorm:"not null;column:aircraft_id"`
+	SeatNumber   string    `gorm:"size:10;not null;column:seat_number"`
+	ClassType    string    `gorm:"not null;column:class_type"`
+	SeatType     string    `gorm:"not null;column:seat_type"`
+	RowNumber    int       `gorm:"not null;column:row_number"`
+	ColumnLetter string    `gorm:"size:1;not null;column:column_letter"`
+	IsExitRow    bool      `gorm:"default:false;column:is_exit_row"`
+	ExtraLegroom bool      `gorm:"default:false;column:extra_legroom"`
+	Blocked      bool      `gorm:"default:false;column:blocked"`
+	CreatedAt    time.Time `gorm:"default:CURRENT_TIMESTAMP;column:created_at"`
+	
+	// Foreign key relationship
+	Aircraft Aircraft `gorm:"foreignKey:AircraftID;references:ID"`
+}
+
+func (SeatMap) TableName() string {
+	return "seat_maps"
+}

--- a/internal/models/system_settings.go
+++ b/internal/models/system_settings.go
@@ -1,0 +1,20 @@
+package models
+
+import (
+	"time"
+)
+
+type SystemSetting struct {
+	ID           uint      `gorm:"primaryKey;column:id"`
+	SettingKey   string    `gorm:"size:100;uniqueIndex;not null;column:setting_key"`
+	SettingValue string    `gorm:"type:text;not null;column:setting_value"`
+	SettingType  string    `gorm:"default:'STRING';column:setting_type"`
+	Description  string    `gorm:"type:text;column:description"`
+	IsPublic     bool      `gorm:"default:false;column:is_public"`
+	CreatedAt    time.Time `gorm:"default:CURRENT_TIMESTAMP;column:created_at"`
+	UpdatedAt    time.Time `gorm:"default:CURRENT_TIMESTAMP;column:updated_at"`
+}
+
+func (SystemSetting) TableName() string {
+	return "system_settings"
+}

--- a/internal/models/users.go
+++ b/internal/models/users.go
@@ -1,0 +1,22 @@
+package models
+
+import (
+	"time"
+)
+
+type User struct {
+	ID           uint      `gorm:"primaryKey;column:id"`
+	Username     string    `gorm:"size:50;uniqueIndex;not null;column:username"`
+	PasswordHash string    `gorm:"size:255;not null;column:password_hash"`
+	Email        string    `gorm:"size:100;uniqueIndex;not null;column:email"`
+	Phone        string    `gorm:"size:20;column:phone"`
+	FirstName    string    `gorm:"size:50;column:first_name"`
+	LastName     string    `gorm:"size:50;column:last_name"`
+	Active       bool      `gorm:"default:true;column:active"`
+	CreatedAt    time.Time `gorm:"default:CURRENT_TIMESTAMP;column:created_at"`
+	UpdatedAt    time.Time `gorm:"default:CURRENT_TIMESTAMP;column:updated_at"`
+}
+
+func (User) TableName() string {
+	return "users"
+}


### PR DESCRIPTION
      Created complete set of Go model structs with GORM annotations for all database tables:
      - Core entities: airlines, airports, aircraft, flights, flight_schedules
      - Booking system: users, bookings, booking_passengers, booking_payments
      - Inventory management: flight_inventory
      - Seat management: seat_maps, seat_assignments
      - Overbooking system: overbooking_rules, overbooking_history, compensation_rules
      - Analytics: popular_routes, search_analytics
      - System: system_settings, api_rate_limits

      All models include:
      - Proper GORM column mappings without JSON tags
      - Foreign key relationships
      - Table name methods
      - Time field handling with proper types